### PR TITLE
Enable no-error mode for p192 curve

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -625,7 +625,7 @@ func namedCurveFromOID(oid asn1.ObjectIdentifier, nfe *NonFatalErrors) elliptic.
 	case oid.Equal(OIDNamedCurveP521):
 		return elliptic.P521()
 	case oid.Equal(OIDNamedCurveP192):
-		nfe.AddError(errors.New("insecure curve (secp192r1) specified"))
+		// nfe.AddError(errors.New("insecure curve (secp192r1) specified"))
 		return secp192r1()
 	}
 	return nil

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -2622,7 +2622,7 @@ func TestParseCertificateFail(t *testing.T) {
 		{desc: "RSAParamsNonNULL", in: "testdata/invalid/xf-pubkey-rsa-param-nonnull.pem", wantErr: "RSA key missing NULL parameters"},
 		{desc: "EmptyEKU", in: "testdata/invalid/xf-ext-extended-key-usage-empty.pem", wantErr: "empty ExtendedKeyUsage"},
 		{desc: "EKUEmptyOID", in: "testdata/invalid/xf-ext-extended-key-usage-empty-oid.pem", wantErr: "zero length OBJECT IDENTIFIER"},
-		{desc: "SECp192r1TooShort", in: "testdata/invalid/xf-pubkey-ecdsa-secp192r1.pem", wantErr: "insecure curve (secp192r1)"},
+		//{desc: "SECp192r1TooShort", in: "testdata/invalid/xf-pubkey-ecdsa-secp192r1.pem", wantErr: "insecure curve (secp192r1)"},
 		{desc: "SerialNumIntegerNotMinimal", in: "testdata/invalid/xf-der-invalid-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
 		{desc: "RSAIntegerNotMinimal", in: "testdata/invalid/xf-der-pubkey-rsa-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
 		{desc: "SubjectNonPrintable", in: "testdata/invalid/xf-subject-nonprintable.pem", wantErr: "PrintableString contains invalid character"},


### PR DESCRIPTION
Enabled getting `namedCurveFromOID` w/o errors.
We need to use p192r curve